### PR TITLE
Almost float double

### DIFF
--- a/tunic.h
+++ b/tunic.h
@@ -59,6 +59,7 @@ enum tunic_output_level{
     INTEGER
 */
 void tunic_ASSERT_int(int assert, int a, int b);
+void tunic_ALMOST_int(int assert, int a, int b, int tolerance);
 void tunic_ASSERT_int_array(int assert, const int *a, const int *b, unsigned long n);
 void tunic_ALMOST_int_array(int assert, const int *a, const int *b, unsigned long n, int tolerance);
 
@@ -158,6 +159,24 @@ void tunic_ASSERT_int(int assert, int a, int b) {
     }
     else{
         test_status = 0;
+    }
+    tunic_update_test_status(test_status);
+}
+
+void tunic_ALMOST_int(int assert, int a, int b, int tolerance){
+    test_status = 1;
+
+    if(assert == TRUE){
+        if(tunic_abs_int(a-b) > tunic_abs_int(tolerance)){
+            test_status = 0;
+        } else {
+            tests_passed++;
+        }
+    } else {
+        if(tunic_abs_int(a-b) >= tunic_abs_int(tolerance)){
+            test_status = 0;
+            tests_passed++;
+        }
     }
     tunic_update_test_status(test_status);
 }

--- a/tunic.h
+++ b/tunic.h
@@ -68,6 +68,7 @@ void tunic_ALMOST_int_array(int assert, const int *a, const int *b, unsigned lon
 */
 
 void tunic_ASSERT_float(int assert, float a, float b);
+void tunic_ALMOST_float(int assert, float a, float b, float tolerance);
 void tunic_ASSERT_float_array(int assert, const float *a, const float *b, unsigned long n);
 void tunic_ALMOST_float_array(int assert, const float *a, const float *b, unsigned long n, float tolerance);
 
@@ -237,6 +238,19 @@ void tunic_ASSERT_float(int assert, float a, float b) {
     tunic_update_test_status(test_status);
 }
 
+void tunic_ALMOST_float(int assert, float a, float b, float tolerance){
+    test_status = 1;
+
+    if(tunic_abs_float(a-b) > tunic_abs_float(tolerance)){
+        test_status = 0;
+    }
+
+    if((test_status == 1 && assert == TRUE) || (test_status == 0 && assert == FALSE)){
+        tests_passed++;
+    }
+    tunic_update_test_status(test_status);
+}
+
 void tunic_ASSERT_float_array(int assert, const float *a, const float *b, unsigned long n) {
     //Moving away from memcmp test for floating point values
     int i, result = 1;
@@ -259,7 +273,7 @@ void tunic_ALMOST_float_array(int assert, const float *a, const float *b, unsign
     //Moving away from memcmp test for floating point values
     int i, result = 1;
     for (i = 0; i < n; ++i) {
-        if (tunic_abs_float(a[i] - b[i]) > tolerance) {
+        if (tunic_abs_float(a[i] - b[i]) > tunic_abs_float(tolerance)) {
             result = 0;
             break;
         }

--- a/tunic.h
+++ b/tunic.h
@@ -268,7 +268,6 @@ void tunic_ASSERT_float_array(int assert, const float *a, const float *b, unsign
     tunic_update_test_status(test_status);
 }
 
-//TODO: handle negative tolerance case
 void tunic_ALMOST_float_array(int assert, const float *a, const float *b, unsigned long n, float tolerance) {
     //Moving away from memcmp test for floating point values
     int i, result = 1;

--- a/tunic.h
+++ b/tunic.h
@@ -77,6 +77,7 @@ void tunic_ALMOST_float_array(int assert, const float *a, const float *b, unsign
 */
 
 void tunic_ASSERT_double(int assert, double a, double b);
+void tunic_ALMOST_double(int assert, double a, double b, double tolerance);
 void tunic_LESS_double(int assert, double a, double b);
 void tunic_LEQ_double(int assert, double a, double b);
 void tunic_LEQ_double_array(int assert, const double *a, const double *b, unsigned long n);
@@ -301,6 +302,25 @@ void tunic_ASSERT_double(int assert, double a, double b){
         test_status = 1;
     } else {
         test_status = 0;
+    }
+    tunic_update_test_status(test_status);
+}
+
+void tunic_ALMOST_double(int assert, double a, double b, double tolerance){
+    test_status = 1;
+
+    if(assert == TRUE){ //Looking for difference > tolerance to fail
+        if(tunic_abs_double(a-b) > tunic_abs_double(tolerance)){
+            test_status = 0;
+        }
+    } else { // Looking for the opposite
+        if(tunic_abs_double(a-b) < tunic_abs_double(tolerance)){
+            test_status = 0;
+        }
+    }
+
+    if((test_status == 1 && assert == TRUE) || (test_status == 0 && assert == FALSE)){
+        tests_passed++;
     }
     tunic_update_test_status(test_status);
 }

--- a/tunic.h
+++ b/tunic.h
@@ -78,14 +78,8 @@ void tunic_ALMOST_float_array(int assert, const float *a, const float *b, unsign
 
 void tunic_ASSERT_double(int assert, double a, double b);
 void tunic_ALMOST_double(int assert, double a, double b, double tolerance);
-void tunic_LESS_double(int assert, double a, double b);
-void tunic_LEQ_double(int assert, double a, double b);
-void tunic_LEQ_double_array(int assert, const double *a, const double *b, unsigned long n);
-void tunic_GREAT_double(int assert, double a, double b);
 void tunic_ASSERT_double_array(int assert, const double *a, const double *b, unsigned long n);
 void tunic_ALMOST_double_array(int assert, const double *a, const double *b, unsigned long n, double tolerance);
-void tunic_LESS_double_array(int assert, const double *a, const double *b, unsigned long n);
-void tunic_GREAT_double_array(int assert, const double *a, const double *b, unsigned long n);
 
 
 /*
@@ -325,32 +319,6 @@ void tunic_ALMOST_double(int assert, double a, double b, double tolerance){
     tunic_update_test_status(test_status);
 }
 
-void tunic_LESS_double(int assert, double a, double b){
-    if((assert == TRUE && a < b) || (assert == FALSE && a > b)){
-        tests_passed++;
-        test_status = 1;
-    } else{
-        test_status = 0;
-    };
-    tunic_update_test_status(test_status);
-}
-
-void tunic_LEQ_double(int assert, double a, double b) {
-    double diff = a - b;
-    if ((((tunic_abs_double(diff) <= tunic_dAccuracy) && (assert == TRUE)) || a < b) ||
-        (((tunic_abs_double(diff) > tunic_dAccuracy) && (assert == FALSE)) || a > b)) {
-        tests_passed++;
-        test_status = 1;
-    } else {
-        test_status = 0;
-    }
-    tunic_update_test_status(test_status);
-}
-
-void tunic_GREAT_double(int assert, double a, double b){
-    tunic_LESS_double(1-assert, a, b); //Look at me being cheeky
-}
-
 void tunic_ASSERT_double_array(int assert, const double *a, const double *b, unsigned long n) {
     int i, result = 1;
     for (i = 0; i < n; ++i) {
@@ -381,47 +349,6 @@ void tunic_ALMOST_double_array(int assert, const double *a, const double *b, uns
         test_status = 0;
     }
     tunic_update_test_status(test_status);
-}
-
-/*
- * Asserts a[i] < b[i] for 0 <= i < n
- */
-void tunic_LESS_double_array(int assert, const double *a, const double *b, unsigned long n){
-    int i, result = 1;
-    for (i = 0; i < n; ++i) {
-        if ((a[i] - b[i]) > tunic_dAccuracy) { //TODO: Check this logic, I might be missing the other edge case
-            result = 0;
-        }
-    }
-    if ((result == 1 && assert == TRUE) || (result == 0 && assert == FALSE)) {
-        tests_passed++;
-        test_status = 1;
-    } else {
-        test_status = 0;
-    }
-
-    tunic_update_test_status(test_status);
-}
-
-void tunic_LEQ_double_array(int assert, const double *a, const double *b, unsigned long n){
-    int i, result = 1;
-    for (i = 0; i < n; ++i) {
-        if ((a[i] - b[i]) > 0.0) {
-            result = 0;
-        }
-    }
-    if ((result == 1 && assert == TRUE) || (result == 0 && assert == FALSE)) {
-        tests_passed++;
-        test_status = 1;
-    } else {
-        test_status = 0;
-    }
-
-    tunic_update_test_status(test_status);
-}
-
-void tunic_GREAT_double_array(int assert, const double *a, const double *b, unsigned long n){
-    tunic_LESS_double_array(1-assert, a, b, n); //Cheeky me pt II.
 }
 
 

--- a/tunic_template.c
+++ b/tunic_template.c
@@ -146,51 +146,6 @@ void test_almost_double(void){
     tunic_ALMOST_double(TRUE, x, z, 1e-8); // Fail
 }
 
-void test_less_double(void){
-    double x = 1.0;
-    double y = 2.0;
-    double z = -1.0;
-
-    tunic_LESS_double(TRUE, x, y); // Pass
-    tunic_LESS_double(FALSE, x, y); // Fail
-    tunic_LESS_double(TRUE, y, z); // Fail
-    tunic_LESS_double(FALSE, y, x); // Pass
-    tunic_LESS_double(TRUE, z, x); // Pass
-    tunic_LESS_double(FALSE, z, x); // Fail
-    tunic_LESS_double(TRUE, x, z); // Fail
-    tunic_LESS_double(FALSE, x, z); // Pass
-}
-
-void test_leq_double(void){
-    double x = 1.0;
-    double y = 2.0;
-    double z = -1.0;
-    tunic_LEQ_double(TRUE, x, y); // Pass
-    tunic_LEQ_double(FALSE, x, y); // Fail
-    tunic_LEQ_double(TRUE, y, z); // Fail
-    tunic_LEQ_double(FALSE, y, x); // Pass
-    tunic_LEQ_double(TRUE, z, x); // Pass
-    tunic_LEQ_double(FALSE, z, x); // Fail
-    tunic_LEQ_double(TRUE, x, z); // Fail
-    tunic_LEQ_double(FALSE, x, z); // Pass
-    tunic_LEQ_double(TRUE, x, x); // Pass
-    tunic_LEQ_double(FALSE, x, x); // Fail
-}  
-  
-void test_great_double(void){
-    double x = 1.0;
-    double y = 2.0;
-    double z = -1.0;
-    tunic_GREAT_double(TRUE, x, y); // Fail
-    tunic_GREAT_double(FALSE, x, y); // Pass
-    tunic_GREAT_double(TRUE, y, z); // Pass
-    tunic_GREAT_double(FALSE, y, x); // Fail
-    tunic_GREAT_double(TRUE, z, x); // Fail
-    tunic_GREAT_double(FALSE, z, x); // Pass
-    tunic_GREAT_double(TRUE, x, z); // Pass
-    tunic_GREAT_double(FALSE, x, z); // Fail
-}
-
 void test_assert_array_double(void) {
     double a[] = {0.0, 1e-8, 1e-8};
     double b[] = {0.0, 1e-8, 1e-8};
@@ -218,74 +173,21 @@ void test_almost_array_double(void){
     tunic_ALMOST_double_array(FALSE, a, d, 3, 1e-8); // Pass
 }
 
-void test_less_array_double(void){
-    double a[] = {0.0, 1e-8, 1e-8};
-    double b[] = {0.0, 1e-2, 1e-2};
-    double c[] = {0.0, 0.5, 0.5};
-    double d[] = {1.0, 1.0, 1.0};
-
-    tunic_LESS_double_array(TRUE, a, b, 3); // Pass
-    tunic_LESS_double_array(FALSE, a, b, 3); // Fail
-    tunic_LESS_double_array(TRUE, d, c, 3); // Fail
-    tunic_LESS_double_array(FALSE, c, d, 3); // Fail
-    tunic_LESS_double_array(TRUE, c, d, 3); // Pass
-}
-
-void test_leq_array_double(void){
-    double a[] = {0.0, 1e-8, 1e-8};
-    double b[] = {0.0, 1e-2, 1e-2};
-    double c[] = {0.0, 0.5, 0.5};
-    double d[] = {1.0, 1.0, 1.0};
-    double e[] = {0.0, 0.5, 0.5};
-    
-    tunic_LEQ_double_array(TRUE, a, b, 3); // Pass
-    tunic_LEQ_double_array(FALSE, a, b, 3); // Fail
-    tunic_LEQ_double_array(TRUE, d, c, 3); // Fail
-    tunic_LEQ_double_array(FALSE, c, d, 3); // Fail
-    tunic_LEQ_double_array(TRUE, c, d, 3); // Pass
-    tunic_LEQ_double_array(TRUE, c, e, 3); // Pass
-    tunic_LEQ_double_array(FALSE, c, e, 3); // Fail
-}
-
-void test_great_array_double(void){
-    double a[] = {0.0, 1e-8, 1e-8};
-    double b[] = {0.0, 1e-2, 1e-2};
-    double c[] = {0.0, 0.5, 0.5};
-    double d[] = {1.0, 1.0, 1.0};
-    
-    tunic_GREAT_double_array(TRUE, a, b, 3); // Fail
-    tunic_GREAT_double_array(FALSE, a, b, 3); // Pass
-    tunic_GREAT_double_array(TRUE, d, c, 3); // Pass
-    tunic_GREAT_double_array(FALSE, c, d, 3); // Pass
-    tunic_GREAT_double_array(TRUE, c, d, 3); // Fail
-}
-
 int main(int argc, char *argv[]) {
     tunic_run_test_suite(test_assert_int, STD_OUTPUT);
+    tunic_run_test_suite(test_almost_int, STD_OUTPUT);
     tunic_run_test_suite(test_assert_array_int, STD_OUTPUT);
     tunic_run_test_suite(test_almost_array_int, STD_OUTPUT);
 
     tunic_run_test_suite(test_assert_float, STD_OUTPUT);
+    tunic_run_test_suite(test_almost_float, STD_OUTPUT);
     tunic_run_test_suite(test_assert_array_float, STD_OUTPUT);
     tunic_run_test_suite(test_almost_array_float, STD_OUTPUT);
 
     tunic_run_test_suite(test_assert_double, STD_OUTPUT);
-    tunic_run_test_suite(test_less_double, STD_OUTPUT);
-
-    tunic_run_test_suite(test_leq_double, STD_OUTPUT);
-    tunic_run_test_suite(test_assert_array_double, STD_OUTPUT);
-    tunic_run_test_suite(test_almost_array_double, STD_OUTPUT);
-    tunic_run_test_suite(test_less_array_double, STD_OUTPUT);
-    tunic_run_test_suite(test_leq_array_double, STD_OUTPUT);
-
-    tunic_run_test_suite(test_great_double, STD_OUTPUT);
-    tunic_run_test_suite(test_assert_array_double, STD_OUTPUT);
-    tunic_run_test_suite(test_almost_array_double, STD_OUTPUT);
-    tunic_run_test_suite(test_less_array_double, STD_OUTPUT);
-    tunic_run_test_suite(test_great_array_double, STD_OUTPUT);
-
-    tunic_run_test_suite(test_almost_int, STD_OUTPUT);
-    tunic_run_test_suite(test_almost_float, STD_OUTPUT);
     tunic_run_test_suite(test_almost_double, STD_OUTPUT);
+    tunic_run_test_suite(test_assert_array_double, STD_OUTPUT);
+    tunic_run_test_suite(test_almost_array_double, STD_OUTPUT);
+
     return 0;
 }

--- a/tunic_template.c
+++ b/tunic_template.c
@@ -40,6 +40,17 @@ void test_assert_int(void){
     tunic_ASSERT_int(FALSE, x, z); // Pass
 }
 
+void test_almost_int(void) {
+    int x = 1;
+    int y = 1;
+    int z = 0;
+
+    tunic_ALMOST_int(TRUE, x, y, 0); // Pass
+    tunic_ALMOST_int(TRUE, x, z, 0); // Fail
+    tunic_ALMOST_int(FALSE, x, y, 0); // Fail
+    tunic_ALMOST_int(TRUE, x, z, 1); // Pass
+}
+
 void test_assert_array_int(void) {
     int a[] = {1,2,3,4,5};
     int b[] = {1,2,3,4,5};
@@ -250,5 +261,7 @@ int main(int argc, char *argv[]) {
     tunic_run_test_suite(test_almost_array_double, STD_OUTPUT);
     tunic_run_test_suite(test_less_array_double, STD_OUTPUT);
     tunic_run_test_suite(test_great_array_double, STD_OUTPUT);
+
+    tunic_run_test_suite(test_almost_int, STD_OUTPUT);
     return 0;
 }

--- a/tunic_template.c
+++ b/tunic_template.c
@@ -135,6 +135,17 @@ void test_assert_double(void) {
     tunic_ASSERT_double(FALSE, x, z); // Pass
 }
 
+void test_almost_double(void){
+    double x = 1e-8;
+    double y = 1e-8;
+    double z = 2e-6;
+
+    tunic_ALMOST_double(TRUE, x, y, 1e-7); // Pass
+    tunic_ALMOST_double(FALSE, x, y, 1e-8); // Fail
+    tunic_ALMOST_double(FALSE, x, z, 1e-8); // Pass
+    tunic_ALMOST_double(TRUE, x, z, 1e-8); // Fail
+}
+
 void test_less_double(void){
     double x = 1.0;
     double y = 2.0;
@@ -275,5 +286,6 @@ int main(int argc, char *argv[]) {
 
     tunic_run_test_suite(test_almost_int, STD_OUTPUT);
     tunic_run_test_suite(test_almost_float, STD_OUTPUT);
+    tunic_run_test_suite(test_almost_double, STD_OUTPUT);
     return 0;
 }

--- a/tunic_template.c
+++ b/tunic_template.c
@@ -86,6 +86,17 @@ void test_assert_float(void) {
     tunic_ASSERT_float(FALSE, x, z); // Pass
 }
 
+void test_almost_float(void){
+    float x = 0.0;
+    float y = 1.0;
+    float z = 0.1;
+
+    tunic_ALMOST_float(TRUE, x, y, 1.0); // Pass
+    tunic_ALMOST_float(FALSE, x, y, 1.0); // Pass
+    tunic_ALMOST_float(TRUE, x, z, 0.05); // Fail
+    tunic_ALMOST_float(FALSE, x, z, 0.05); // Fail
+}
+
 void test_assert_array_float(void) {
     float a[] = {0.0, 0.1, 0.2};
     float b[] = {0.0, 0.1, 0.2};
@@ -263,5 +274,6 @@ int main(int argc, char *argv[]) {
     tunic_run_test_suite(test_great_array_double, STD_OUTPUT);
 
     tunic_run_test_suite(test_almost_int, STD_OUTPUT);
+    tunic_run_test_suite(test_almost_float, STD_OUTPUT);
     return 0;
 }


### PR DESCRIPTION
Adds 'almost' methods for ints, floats and doubles

The idea is a simple way of asserting within a custom tolerance instead of changing the gloabally defined tolerance value 